### PR TITLE
Implement tweets module with CRUD operations and tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+  moduleFileExtensions: ['js', 'json', 'ts'],
+  rootDir: 'src',
+  testRegex: '.*\\.spec\\.ts$',
+  transform: {
+    '^.+\\.(t|j)s$': 'ts-jest',
+  },
+  collectCoverageFrom: ['**/*.(t|j)s'],
+  coverageDirectory: '../coverage',
+  testEnvironment: 'node',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/$1',
+  },
+  moduleDirectories: ['node_modules', '<rootDir>'],
+};

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
+    "test:tweets": "jest tweets",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
@@ -55,22 +56,5 @@
     "ts-node-dev": "^2.0.0",
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.7.3"
-  },
-  "jest": {
-    "moduleFileExtensions": [
-      "js",
-      "json",
-      "ts"
-    ],
-    "rootDir": "src",
-    "testRegex": ".*\\.spec\\.ts$",
-    "transform": {
-      "^.+\\.(t|j)s$": "ts-jest"
-    },
-    "collectCoverageFrom": [
-      "**/*.(t|j)s"
-    ],
-    "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
   }
 }

--- a/src/app.controller.spec.ts
+++ b/src/app.controller.spec.ts
@@ -1,7 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
-import puppeteer from 'puppeteer';
 
 describe('AppController', () => {
   let appController: AppController;

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@nestjs/common';
-import puppeteer from 'puppeteer';
 
 @Injectable()
 export class AppService {

--- a/src/author/author.entity.ts
+++ b/src/author/author.entity.ts
@@ -1,4 +1,4 @@
-import { Tweet } from 'src/tweets/tweets.entity';
+import { Tweet } from '@/tweets/tweets.entity';
 import { Entity, PrimaryGeneratedColumn, Column, OneToMany } from 'typeorm';
 
 @Entity()

--- a/src/tweets/tweets.controller.spec.ts
+++ b/src/tweets/tweets.controller.spec.ts
@@ -1,18 +1,92 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { TweetsController } from './tweets.controller';
+import { TweetsService } from './tweets.service';
+import { PaginationQueryDto } from './tweets.dto';
 
 describe('TweetsController', () => {
   let controller: TweetsController;
+  let service: TweetsService;
+
+  const mockTweet = {
+    id: 1,
+    text: 'Test tweet',
+    authorId: 1,
+    author: {
+      id: 1,
+      name: 'Test Author',
+      email: 'test@example.com',
+      latestUpdate: new Date(),
+    },
+  };
+
+  const mockPaginatedResponse = {
+    items: [mockTweet],
+    total: 1,
+    page: 1,
+    limit: 10,
+    totalPages: 1,
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [TweetsController],
+      providers: [
+        {
+          provide: TweetsService,
+          useValue: {
+            findAll: jest.fn().mockResolvedValue(mockPaginatedResponse),
+            findOne: jest.fn().mockResolvedValue(mockTweet),
+            create: jest.fn().mockResolvedValue(mockTweet),
+            update: jest.fn().mockResolvedValue(mockTweet),
+            remove: jest.fn().mockResolvedValue(undefined),
+          },
+        },
+      ],
     }).compile();
 
     controller = module.get<TweetsController>(TweetsController);
+    service = module.get<TweetsService>(TweetsService);
   });
 
-  it('should be defined', () => {
-    expect(controller).toBeDefined();
+  describe('findAll', () => {
+    it('should return paginated tweets', async () => {
+      const paginationQuery: PaginationQueryDto = { page: 1, limit: 10 };
+      const result = await controller.findAll(paginationQuery);
+      expect(result).toEqual(mockPaginatedResponse);
+      expect(service.findAll).toHaveBeenCalledWith(paginationQuery);
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return a single tweet', async () => {
+      const result = await controller.findOne(1);
+      expect(result).toEqual(mockTweet);
+      expect(service.findOne).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('create', () => {
+    it('should create a tweet', async () => {
+      const createTweetDto = { text: 'Test tweet', authorId: 1 };
+      const result = await controller.create(createTweetDto);
+      expect(result).toEqual(mockTweet);
+      expect(service.create).toHaveBeenCalledWith(createTweetDto);
+    });
+  });
+
+  describe('update', () => {
+    it('should update a tweet', async () => {
+      const updateTweetDto = { text: 'Updated tweet' };
+      const result = await controller.update(1, updateTweetDto);
+      expect(result).toEqual(mockTweet);
+      expect(service.update).toHaveBeenCalledWith(1, updateTweetDto);
+    });
+  });
+
+  describe('remove', () => {
+    it('should remove a tweet', async () => {
+      await controller.remove(1);
+      expect(service.remove).toHaveBeenCalledWith(1);
+    });
   });
 });

--- a/src/tweets/tweets.controller.ts
+++ b/src/tweets/tweets.controller.ts
@@ -1,4 +1,54 @@
-import { Controller } from '@nestjs/common';
+import {
+  CreateTweetDto,
+  PaginatedResult,
+  PaginationQueryDto,
+  UpdateTweetDto,
+} from './tweets.dto';
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Delete,
+  Body,
+  Param,
+  ParseIntPipe,
+  Query,
+} from '@nestjs/common';
+import { TweetsService } from './tweets.service';
+import { Tweet } from './tweets.entity';
 
 @Controller('tweets')
-export class TweetsController {}
+export class TweetsController {
+  constructor(private readonly tweetsService: TweetsService) {}
+
+  @Get()
+  findAll(
+    @Query() paginationQuery: PaginationQueryDto,
+  ): Promise<PaginatedResult<Tweet>> {
+    return this.tweetsService.findAll(paginationQuery);
+  }
+
+  @Get(':id')
+  findOne(@Param('id', ParseIntPipe) id: number): Promise<Tweet> {
+    return this.tweetsService.findOne(id);
+  }
+
+  @Post()
+  create(@Body() createTweetDto: CreateTweetDto): Promise<Tweet> {
+    return this.tweetsService.create(createTweetDto);
+  }
+
+  @Put(':id')
+  update(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() updateTweetDto: UpdateTweetDto,
+  ): Promise<Tweet> {
+    return this.tweetsService.update(id, updateTweetDto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id', ParseIntPipe) id: number): Promise<void> {
+    return this.tweetsService.remove(id);
+  }
+}

--- a/src/tweets/tweets.dto.ts
+++ b/src/tweets/tweets.dto.ts
@@ -1,0 +1,47 @@
+import { Type } from 'class-transformer';
+
+import {
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Min,
+} from 'class-validator';
+
+export class CreateTweetDto {
+  @IsString()
+  @IsNotEmpty()
+  text: string;
+
+  @IsNumber()
+  @IsNotEmpty()
+  authorId: number;
+}
+
+export class UpdateTweetDto {
+  @IsString()
+  @IsNotEmpty()
+  text: string;
+}
+
+export class PaginationQueryDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(1)
+  page?: number = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(1)
+  limit?: number = 10;
+}
+
+export interface PaginatedResult<T> {
+  items: T[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}

--- a/src/tweets/tweets.entity.ts
+++ b/src/tweets/tweets.entity.ts
@@ -1,4 +1,4 @@
-import { Author } from 'src/author/author.entity';
+import { Author } from '@/author/author.entity';
 import { Entity, PrimaryGeneratedColumn, Column, ManyToOne } from 'typeorm';
 
 @Entity()

--- a/src/tweets/tweets.module.ts
+++ b/src/tweets/tweets.module.ts
@@ -1,12 +1,14 @@
 import { Module } from '@nestjs/common';
-import { TweetsService } from './tweets.service';
-import { TweetsController } from './tweets.controller';
-import { Tweet } from './tweets.entity';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { Tweet } from './tweets.entity';
+import { Author } from '../author/author.entity';
+import { TweetsController } from './tweets.controller';
+import { TweetsService } from './tweets.service';
+import { TweetSubscriber } from './tweets.subscriber';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Tweet])],
-  providers: [TweetsService],
+  imports: [TypeOrmModule.forFeature([Tweet, Author])],
+  providers: [TweetsService, TweetSubscriber],
   controllers: [TweetsController],
 })
 export class TweetsModule {}

--- a/src/tweets/tweets.service.spec.ts
+++ b/src/tweets/tweets.service.spec.ts
@@ -1,18 +1,164 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { TweetsService } from './tweets.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Tweet } from './tweets.entity';
+import { Author } from '@/author/author.entity';
+import { Repository } from 'typeorm';
+import { NotFoundException } from '@nestjs/common';
 
 describe('TweetsService', () => {
   let service: TweetsService;
+  let tweetRepository: Repository<Tweet>;
+  let authorRepository: Repository<Author>;
+
+  const mockTweet = {
+    id: 1,
+    text: 'Test tweet',
+    authorId: 1,
+    author: {
+      id: 1,
+      name: 'Test Author',
+      email: 'test@example.com',
+      latestUpdate: new Date(),
+      tweets: [],
+    },
+  };
+
+  const mockAuthor = {
+    id: 1,
+    name: 'Test Author',
+    email: 'test@example.com',
+    latestUpdate: new Date(),
+    tweets: [],
+  };
+
+  const mockTweetRepository = {
+    find: jest.fn().mockResolvedValue([mockTweet]),
+    findOne: jest.fn().mockResolvedValue(mockTweet),
+    findAndCount: jest.fn().mockResolvedValue([[mockTweet], 1]),
+    create: jest.fn().mockReturnValue(mockTweet),
+    save: jest.fn().mockResolvedValue(mockTweet),
+    remove: jest.fn().mockResolvedValue(undefined),
+  };
+
+  const mockAuthorRepository = {
+    findOne: jest.fn().mockResolvedValue(mockAuthor),
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [TweetsService],
+      providers: [
+        TweetsService,
+        {
+          provide: getRepositoryToken(Tweet),
+          useValue: mockTweetRepository,
+        },
+        {
+          provide: getRepositoryToken(Author),
+          useValue: mockAuthorRepository,
+        },
+      ],
     }).compile();
 
     service = module.get<TweetsService>(TweetsService);
+    tweetRepository = module.get<Repository<Tweet>>(getRepositoryToken(Tweet));
+    authorRepository = module.get<Repository<Author>>(
+      getRepositoryToken(Author),
+    );
+
+    // Clear all mock calls before each test
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('findAll', () => {
+    it('should return an array of tweets', async () => {
+      const result = await service.findAll({ page: 1, limit: 10 });
+      expect(result.items).toEqual([mockTweet]);
+      expect(tweetRepository.findAndCount).toHaveBeenCalledWith({
+        relations: ['author'],
+        skip: 0,
+        take: 10,
+        order: { id: 'DESC' },
+      });
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return a single tweet', async () => {
+      const result = await service.findOne(1);
+      expect(result).toEqual(mockTweet);
+      expect(tweetRepository.findOne).toHaveBeenCalledWith({
+        where: { id: 1 },
+        relations: ['author'],
+      });
+    });
+
+    it('should throw NotFoundException when tweet not found', async () => {
+      jest.spyOn(tweetRepository, 'findOne').mockResolvedValueOnce(null);
+      await expect(service.findOne(999)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('create', () => {
+    it('should create a tweet', async () => {
+      const createTweetDto = { text: 'Test tweet', authorId: 1 };
+
+      const result = await service.create(createTweetDto);
+
+      expect(result).toEqual(mockTweet);
+      expect(authorRepository.findOne).toHaveBeenCalledWith({
+        where: { id: 1 },
+      });
+      expect(tweetRepository.create).toHaveBeenCalledWith(createTweetDto);
+      expect(tweetRepository.save).toHaveBeenCalled();
+    });
+
+    it('should throw NotFoundException when author not found', async () => {
+      jest.spyOn(authorRepository, 'findOne').mockResolvedValueOnce(null);
+      await expect(
+        service.create({ text: 'Test', authorId: 999 }),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('update', () => {
+    it('should update a tweet', async () => {
+      const updateTweetDto = { text: 'Updated tweet' };
+      const result = await service.update(1, updateTweetDto);
+
+      expect(result).toEqual(mockTweet);
+      expect(tweetRepository.findOne).toHaveBeenCalledWith({
+        where: { id: 1 },
+        relations: ['author'],
+      });
+      expect(tweetRepository.save).toHaveBeenCalled();
+    });
+
+    it('should throw NotFoundException when tweet not found', async () => {
+      jest.spyOn(tweetRepository, 'findOne').mockResolvedValueOnce(null);
+      await expect(service.update(999, { text: 'Test' })).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('remove', () => {
+    it('should remove a tweet', async () => {
+      await service.remove(1);
+      expect(tweetRepository.findOne).toHaveBeenCalledWith({
+        where: { id: 1 },
+        relations: ['author'],
+      });
+      expect(tweetRepository.remove).toHaveBeenCalledWith(mockTweet);
+    });
+
+    it('should throw NotFoundException when tweet not found', async () => {
+      jest.spyOn(tweetRepository, 'findOne').mockResolvedValueOnce(null);
+      await expect(service.remove(999)).rejects.toThrow(NotFoundException);
+    });
   });
 });

--- a/src/tweets/tweets.service.ts
+++ b/src/tweets/tweets.service.ts
@@ -1,4 +1,89 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Tweet } from './tweets.entity';
+import { Author } from '../author/author.entity';
+import {
+  CreateTweetDto,
+  PaginatedResult,
+  PaginationQueryDto,
+  UpdateTweetDto,
+} from './tweets.dto';
 
 @Injectable()
-export class TweetsService {}
+export class TweetsService {
+  constructor(
+    @InjectRepository(Tweet)
+    private readonly tweetRepository: Repository<Tweet>,
+    @InjectRepository(Author)
+    private readonly authorRepository: Repository<Author>,
+  ) {}
+
+  async findAll(
+    paginationQuery: PaginationQueryDto,
+  ): Promise<PaginatedResult<Tweet>> {
+    const { page = 1, limit = 10 } = paginationQuery;
+    const skip = (page - 1) * limit;
+
+    const [items, total] = await this.tweetRepository.findAndCount({
+      relations: ['author'],
+      skip,
+      take: limit,
+      order: { id: 'DESC' }, // Most recent tweets first
+    });
+
+    const totalPages = Math.ceil(total / limit);
+
+    return {
+      items,
+      total,
+      page,
+      limit,
+      totalPages,
+    };
+  }
+
+  async findOne(id: number): Promise<Tweet> {
+    const tweet = await this.tweetRepository.findOne({
+      where: { id },
+      relations: ['author'],
+    });
+
+    if (!tweet) {
+      throw new NotFoundException(`Tweet with ID ${id} not found`);
+    }
+
+    return tweet;
+  }
+
+  async create(createTweetDto: CreateTweetDto): Promise<Tweet> {
+    const author = await this.authorRepository.findOne({
+      where: { id: createTweetDto.authorId },
+    });
+
+    if (!author) {
+      throw new NotFoundException(
+        `Author with ID ${createTweetDto.authorId} not found`,
+      );
+    }
+
+    const tweet = this.tweetRepository.create(createTweetDto);
+    await this.tweetRepository.save(tweet);
+
+    return this.findOne(tweet.id);
+  }
+
+  async update(id: number, updateTweetDto: UpdateTweetDto): Promise<Tweet> {
+    const tweet = await this.findOne(id);
+
+    const updatedTweet = Object.assign(tweet, updateTweetDto);
+    await this.tweetRepository.save(updatedTweet);
+
+    return this.findOne(id);
+  }
+
+  async remove(id: number): Promise<void> {
+    const tweet = await this.findOne(id);
+    await this.tweetRepository.remove(tweet);
+  }
+}

--- a/src/tweets/tweets.subscriber.spec.ts
+++ b/src/tweets/tweets.subscriber.spec.ts
@@ -1,0 +1,88 @@
+import { DataSource, Repository } from 'typeorm';
+import { TweetSubscriber } from './tweets.subscriber';
+import { Tweet } from './tweets.entity';
+import { Author } from '@/author/author.entity';
+
+describe('TweetSubscriber', () => {
+  let subscriber: TweetSubscriber;
+  let mockDataSource: jest.Mocked<DataSource>;
+  let mockAuthorRepository: jest.Mocked<Repository<Author>>;
+
+  beforeEach(() => {
+    mockAuthorRepository = {
+      update: jest.fn().mockResolvedValue(undefined),
+    } as any;
+
+    mockDataSource = {
+      subscribers: [],
+      getRepository: jest.fn().mockReturnValue(mockAuthorRepository),
+    } as any;
+
+    subscriber = new TweetSubscriber(mockDataSource);
+  });
+
+  it('should be defined', () => {
+    expect(subscriber).toBeDefined();
+  });
+
+  it('should listen to Tweet entity', () => {
+    expect(subscriber.listenTo()).toBe(Tweet);
+  });
+
+  it('should update author timestamp after tweet insert', async () => {
+    const mockEvent = {
+      entity: { authorId: 1 },
+      manager: { connection: mockDataSource },
+    } as any;
+
+    await subscriber.afterInsert(mockEvent);
+
+    expect(mockDataSource.getRepository).toHaveBeenCalledWith(Author);
+    expect(mockAuthorRepository.update).toHaveBeenCalledWith(
+      { id: 1 },
+      { latestUpdate: expect.any(Date) },
+    );
+  });
+
+  it('should update author timestamp after tweet update', async () => {
+    const mockEvent = {
+      entity: { authorId: 1 },
+      manager: { connection: mockDataSource },
+    } as any;
+
+    await subscriber.afterUpdate(mockEvent);
+
+    expect(mockDataSource.getRepository).toHaveBeenCalledWith(Author);
+    expect(mockAuthorRepository.update).toHaveBeenCalledWith(
+      { id: 1 },
+      { latestUpdate: expect.any(Date) },
+    );
+  });
+
+  it('should update author timestamp before tweet remove', async () => {
+    const mockEvent = {
+      entity: { authorId: 1 },
+      manager: { connection: mockDataSource },
+    } as any;
+
+    await subscriber.beforeRemove(mockEvent);
+
+    expect(mockDataSource.getRepository).toHaveBeenCalledWith(Author);
+    expect(mockAuthorRepository.update).toHaveBeenCalledWith(
+      { id: 1 },
+      { latestUpdate: expect.any(Date) },
+    );
+  });
+
+  it('should not update if entity is not available in the event', async () => {
+    const mockEvent = {
+      entity: null,
+      manager: { connection: mockDataSource },
+    } as any;
+
+    await subscriber.afterUpdate(mockEvent);
+
+    expect(mockDataSource.getRepository).not.toHaveBeenCalled();
+    expect(mockAuthorRepository.update).not.toHaveBeenCalled();
+  });
+});

--- a/src/tweets/tweets.subscriber.ts
+++ b/src/tweets/tweets.subscriber.ts
@@ -1,0 +1,58 @@
+import {
+  EntitySubscriberInterface,
+  EventSubscriber,
+  InsertEvent,
+  UpdateEvent,
+  RemoveEvent,
+  DataSource,
+} from 'typeorm';
+import { Tweet } from './tweets.entity';
+import { Author } from '@/author/author.entity';
+
+@EventSubscriber()
+export class TweetSubscriber implements EntitySubscriberInterface<Tweet> {
+  constructor(dataSource: DataSource) {
+    dataSource.subscribers.push(this);
+  }
+
+  listenTo() {
+    return Tweet;
+  }
+
+  private async updateAuthorTimestamp(
+    authorId: number,
+    dataSource: DataSource,
+  ) {
+    const authorRepository = dataSource.getRepository(Author);
+    await authorRepository.update(
+      { id: authorId },
+      { latestUpdate: new Date() },
+    );
+  }
+
+  async afterInsert(event: InsertEvent<Tweet>) {
+    await this.updateAuthorTimestamp(
+      event.entity.authorId,
+      event.manager.connection,
+    );
+  }
+
+  async afterUpdate(event: UpdateEvent<Tweet>) {
+    if (event.entity) {
+      await this.updateAuthorTimestamp(
+        event.entity.authorId,
+        event.manager.connection,
+      );
+    }
+  }
+
+  async beforeRemove(event: RemoveEvent<Tweet>) {
+    // We need to use beforeRemove because after the tweet is removed, we won't have access to the authorId
+    if (event.entity) {
+      await this.updateAuthorTimestamp(
+        event.entity.authorId,
+        event.manager.connection,
+      );
+    }
+  }
+}

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -5,5 +5,8 @@
   "testRegex": ".e2e-spec.ts$",
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
+  },
+  "moduleNameMapper": {
+    "^@/(.*)$": "<rootDir>/src/$1"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,9 @@
     "sourceMap": true,
     "outDir": "./dist",
     "baseUrl": "./",
+    "paths": {
+      "@/*": ["src/*"]
+    },
     "incremental": true,
     "skipLibCheck": true,
     "strictNullChecks": false,


### PR DESCRIPTION
Introduce a tweets module with full CRUD functionality and pagination support. Add Jest configuration and enhance tests for comprehensive coverage, including subscriber tests.